### PR TITLE
Correction of an installation error in a future version of zpm

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="sync-dstime.ZPM">
     <Module>
       <Name>sync-dstime</Name>
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
       <Description>Sync Data with DSTIME</Description>
       <Keywords>DSTIME, data sync</Keywords>
       <Packaging>module</Packaging>

--- a/src/OBJ/Address.cls
+++ b/src/OBJ/Address.cls
@@ -13,4 +13,27 @@ Property State As %String(MAXLEN = 2, POPSPEC = "USState()");
 
 /// The 5-digit U.S. Zone Improvement Plan (ZIP) code.
 Property Zip As %String(MAXLEN = 5, POPSPEC = "USZip()");
+
+Storage Default
+{
+<Data name="AddressState">
+<Value name="1">
+<Value>Street</Value>
+</Value>
+<Value name="2">
+<Value>City</Value>
+</Value>
+<Value name="3">
+<Value>State</Value>
+</Value>
+<Value name="4">
+<Value>Zip</Value>
+</Value>
+</Data>
+<State>AddressState</State>
+<StreamLocation>^OBJ.AddressS</StreamLocation>
+<Type>%Storage.Serial</Type>
 }
+
+}
+

--- a/src/OBJ/Person.cls
+++ b/src/OBJ/Person.cls
@@ -61,9 +61,7 @@ Method PrintPerson()
 
 /// A simple, sample method: add two numbers (<var>x</var> and <var>y</var>) 
 /// and return the result.
-Method Addition(
-    x As %Integer = 1,
-    y As %Integer = 1) As %Integer
+Method Addition(x As %Integer = 1, y As %Integer = 1) As %Integer
 {
     Quit x + y // comment
 }
@@ -110,9 +108,7 @@ ClassMethod PrintPersonsSQL()
 /// class method. This method can be called as a stored procedure via 
 /// ODBC or JDBC.<br>
 /// In this case this method returns the concatenation of a string value.
-ClassMethod StoredProcTest(
-    name As %String,
-    ByRef response As %String) As %Integer [ SqlName = Stored_Procedure_Test, SqlProc ]
+ClassMethod StoredProcTest(name As %String, ByRef response As %String) As %Integer [ SqlName = Stored_Procedure_Test, SqlProc ]
 {
     // Set response to the concatenation of name.
     Set response = name _ "||" _ name
@@ -126,10 +122,7 @@ ClassMethod StoredProcTest(
 /// using embedded SQL. The update modifies the embedded properties 
 /// <var>Home.City</var> and <var>Home.State</var> for all rows whose 
 /// <var>Home.Zip</var> is equal to <var>zip</var>.
-ClassMethod UpdateProcTest(
-    zip As %String,
-    city As %String,
-    state As %String) As %Integer [ SqlProc ]
+ClassMethod UpdateProcTest(zip As %String, city As %String, state As %String) As %Integer [ SqlProc ]
 {
     New %ROWCOUNT,%ROWID
     
@@ -159,5 +152,41 @@ WHERE (Name %STARTSWITH :name)
 ORDER BY Name
 }
 
+Storage Default
+{
+<Data name="PersonDefaultData">
+<Value name="1">
+<Value>%%CLASSNAME</Value>
+</Value>
+<Value name="2">
+<Value>Name</Value>
+</Value>
+<Value name="3">
+<Value>SSN</Value>
+</Value>
+<Value name="4">
+<Value>DOB</Value>
+</Value>
+<Value name="5">
+<Value>Home</Value>
+</Value>
+<Value name="6">
+<Value>Office</Value>
+</Value>
+<Value name="7">
+<Value>Spouse</Value>
+</Value>
+<Value name="8">
+<Value>FavoriteColors</Value>
+</Value>
+</Data>
+<DataLocation>^OBJ.PersonD</DataLocation>
+<DefaultData>PersonDefaultData</DefaultData>
+<IdLocation>^OBJ.PersonD</IdLocation>
+<IndexLocation>^OBJ.PersonI</IndexLocation>
+<StreamLocation>^OBJ.PersonS</StreamLocation>
+<Type>%Storage.Persistent</Type>
+}
 
 }
+


### PR DESCRIPTION
This module has a persistent class without any specific storage and this is stated in the error.
The author must define the Storage and publish the new version. The new version of the zpm will have an installation error.
 Update the release in Open Exchange please.
https://openexchange.intersystems.com/markdown?url=assets%2Fdoc%2Freleases.md
Thanks.

%SYS>ver
%SYS> zpm 0.2.15-dev.228.5
zapm:USER>install sync-dstime
 
[sync-dstime]   Reload START (D:\InterSystems\IRISPY\mgr\.modules\USER\sync-dstime\1.0.3\)
[sync-dstime]   Reload SUCCESS
[sync-dstime]   Module object refreshed.
[sync-dstime]   Validate START
[sync-dstime]   Validate SUCCESS
[sync-dstime]   Compile START
[sync-dstime]   Compile FAILURE
ERROR! Storage on class OBJ.Address modified by storage compiler, developer should have run ^build to make sure all storage is updated correctly and saved to Perforce